### PR TITLE
Fix quote in readme code

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This document is for developers actively working _on_ the project, rather than c
 
     1. A single line `Rakefile.rb`
 
-      ```require_relative '../../../rakefile_local.rb’```
+      ```require_relative '../../../rakefile_local.rb'```
 
     2. A single line `sources/Rakefile.rb`
 


### PR DESCRIPTION
Remove smart quote and replace it with a normal (dumb?) one. Makes it easier to copy and paste.
